### PR TITLE
Expose custom types in python

### DIFF
--- a/tarok/python/main.py
+++ b/tarok/python/main.py
@@ -8,9 +8,8 @@ def main():
     tarok_state = tarok_game.new_initial_tarok_state()
     print("Legal actions: {}".format(tarok_state.legal_actions()))
     cfr_solver = sp.CFRSolver(tarok_game)
-    print("CFR policy: {}".format(
-        cfr_solver.current_policy().action_probabilities(tarok_state)),
-    )
+    policy = cfr_solver.current_policy().action_probabilities(tarok_state)
+    print("CFR policy: {}".format(policy))
 
 
 if __name__ == '__main__':

--- a/tarok/python/main.py
+++ b/tarok/python/main.py
@@ -3,8 +3,14 @@ import pytarok as ta
 
 
 def main():
-    tarok_game = ta.new_tarok_game({})
-    print(tarok_game.num_distinct_actions())
+    tarok_game = ta.TarokGame({})
+    print("Number of players: {:d}".format(tarok_game.num_players()))
+    tarok_state = tarok_game.new_initial_tarok_state()
+    print("Legal actions: {}".format(tarok_state.legal_actions()))
+    cfr_solver = sp.CFRSolver(tarok_game)
+    print("CFR policy: {}".format(
+        cfr_solver.current_policy().action_probabilities(tarok_state)),
+    )
 
 
 if __name__ == '__main__':

--- a/tarok/python/main.py
+++ b/tarok/python/main.py
@@ -3,10 +3,14 @@ import pytarok as ta
 
 
 def main():
+    # game and state are pyspiel's subtypes, i.e. TarokGame and TarokState
     tarok_game = ta.TarokGame({})
     print("Number of players: {:d}".format(tarok_game.num_players()))
     tarok_state = tarok_game.new_initial_tarok_state()
     print("Legal actions: {}".format(tarok_state.legal_actions()))
+    print("Human readable action: {}".format(tarok_game.action_to_card(0)))
+
+    # they can be used with pyspiel algorithm implementations
     cfr_solver = sp.CFRSolver(tarok_game)
     policy = cfr_solver.current_policy().action_probabilities(tarok_state)
     print("CFR policy: {}".format(policy))

--- a/tarok/python/requirements.txt
+++ b/tarok/python/requirements.txt
@@ -1,2 +1,3 @@
+autopep8==1.5.2
 cpplint == 1.4.5
 -r ../libs/open_spiel/requirements.txt

--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -23,6 +23,8 @@ bool TarokCard::IsTrula() const {
   return suit == CardSuit::kTaroks && points == 5;
 }
 
+std::string TarokCard::ToString() const { return long_name; }
+
 // overload cards operator<< so that we can output instances on output stream
 std::ostream &operator<<(std::ostream &stream, const TarokCard &card) {
   return stream << card.long_name;

--- a/tarok/src/cards.h
+++ b/tarok/src/cards.h
@@ -15,6 +15,7 @@ struct TarokCard {
             std::string long_name);
 
   bool IsTrula() const;
+  std::string ToString() const;
 
   const CardSuit suit;
   const int rank;

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -66,11 +66,6 @@ TarokCard TarokGame::ActionToCard(open_spiel::Action action) const {
   return kCardDeck[action];
 }
 
-std::shared_ptr<const open_spiel::Game> NewGame(
-    const open_spiel::GameParameters& params) {
-  return NewTarokGame(params);
-}
-
 std::shared_ptr<const TarokGame> NewTarokGame(
     const open_spiel::GameParameters& params) {
   return std::shared_ptr<const TarokGame>(new TarokGame(params));

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -39,9 +39,6 @@ class TarokGame : public open_spiel::Game {
 
 // instantiate the game instance via a shared_ptr
 // (see Game declaration comments in open_spiel/spiel.h)
-std::shared_ptr<const open_spiel::Game> NewGame(
-    const open_spiel::GameParameters& params);
-
 std::shared_ptr<const TarokGame> NewTarokGame(
     const open_spiel::GameParameters& params);
 

--- a/tarok/src/py_bindings.cpp
+++ b/tarok/src/py_bindings.cpp
@@ -1,13 +1,32 @@
 /* Copyright 2020 Semantic Weights. All rights reserved. */
 
+#include "open_spiel/spiel.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "src/game.h"
+#include "src/state.h"
 
 namespace tarok {
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(pytarok, m) { m.def("new_tarok_game", &NewGame); }
+PYBIND11_MODULE(pytarok, m) {
+  py::module::import("pyspiel");
+
+  // game object
+  py::class_<TarokGame, open_spiel::Game, std::shared_ptr<TarokGame>>
+      tarok_game(m, "TarokGame");
+
+  tarok_game.def(py::init([](const open_spiel::GameParameters& params) {
+    // instantiate the game instance via a shared_ptr
+    // (see Game declaration comments in open_spiel/spiel.h)
+    return std::shared_ptr<TarokGame>(new TarokGame(params));
+  }));
+
+  tarok_game.def("new_initial_tarok_state", &TarokGame::NewInitialTarokState);
+
+  // state object
+  py::class_<TarokState, open_spiel::State> tarok_state(m, "TarokState");
+}
 
 }  // namespace tarok

--- a/tarok/src/py_bindings.cpp
+++ b/tarok/src/py_bindings.cpp
@@ -3,6 +3,7 @@
 #include "open_spiel/spiel.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
+#include "src/cards.h"
 #include "src/game.h"
 #include "src/state.h"
 
@@ -24,9 +25,14 @@ PYBIND11_MODULE(pytarok, m) {
   }));
 
   tarok_game.def("new_initial_tarok_state", &TarokGame::NewInitialTarokState);
+  tarok_game.def("action_to_card", &TarokGame::ActionToCard);
 
   // state object
   py::class_<TarokState, open_spiel::State> tarok_state(m, "TarokState");
+
+  // card object
+  py::class_<TarokCard> tarok_card(m, "TarokCard");
+  tarok_card.def("__str__", &TarokCard::ToString);
 }
 
 }  // namespace tarok


### PR DESCRIPTION
Expose tarok game and state types instead of open spiel base types so that we can later implement custom methods and use them within python.

Output:
<img width="645" alt="Screenshot 2020-05-13 at 01 24 51" src="https://user-images.githubusercontent.com/3806837/81755372-e1b74880-94b8-11ea-9f4a-04876fad2fcd.png">