### PR TITLE
Implement game phases

### DIFF
--- a/tarok/python/main.py
+++ b/tarok/python/main.py
@@ -3,17 +3,17 @@ import pytarok as ta
 
 
 def main():
-    # game and state are pyspiel's subtypes, i.e. TarokGame and TarokState
-    tarok_game = ta.TarokGame({})
-    print("Number of players: {:d}".format(tarok_game.num_players()))
-    tarok_state = tarok_game.new_initial_tarok_state()
-    print("Legal actions: {}".format(tarok_state.legal_actions()))
-    print("Human readable action: {}".format(tarok_game.action_to_card(0)))
+    game = ta.TarokGame({'seed': sp.GameParameter(0)})
+    state = game.new_initial_tarok_state()
+    print("Current player: {}".format(state.current_player()))
+    print("Legal actions: {}".format(state.legal_actions()))
+    print("Chance outcomes: {}\n".format(state.chance_outcomes()))
 
-    # they can be used with pyspiel algorithm implementations
-    cfr_solver = sp.CFRSolver(tarok_game)
-    policy = cfr_solver.current_policy().action_probabilities(tarok_state)
-    print("CFR policy: {}".format(policy))
+    print("Dealing cards...")
+    state.apply_action(0)
+    print("Current player: {}".format(state.current_player()))
+    print("Player cards: {}".format(state.player_cards(0)))
+    print("Talon: {}".format(state.talon()))
 
 
 if __name__ == '__main__':

--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -30,7 +30,7 @@ std::ostream &operator<<(std::ostream &stream, const TarokCard &card) {
   return stream << card.long_name;
 }
 
-CardDeck InitializeCardDeck() {
+std::array<TarokCard, 54> InitializeCardDeck() {
   static const std::array<TarokCard, 54> deck = {
       // taroks
       TarokCard(CardSuit::kTaroks, 8, 5, "T1", "Pagat"),
@@ -94,7 +94,7 @@ CardDeck InitializeCardDeck() {
   return deck;
 }
 
-DealtCards DealCards(int numPlayers, int seed) {
+DealtCards DealCards(int num_players, int seed) {
   // create vector of card indices
   std::vector<int> cards(54);
   std::iota(cards.begin(), cards.end(), 0);
@@ -107,15 +107,15 @@ DealtCards DealCards(int numPlayers, int seed) {
   std::vector<int> talon(begin, end);
 
   // deal the rest of the cards to players
-  int numCardsPerPlayer = 48 / numPlayers;
+  int num_cards_per_player = 48 / num_players;
   std::vector<std::vector<int>> players_cards;
-  players_cards.reserve(numPlayers);
+  players_cards.reserve(num_players);
 
   std::advance(begin, 6);
-  for (int i = 0; i < numPlayers; i++) {
-    std::advance(end, numCardsPerPlayer);
+  for (int i = 0; i < num_players; i++) {
+    std::advance(end, num_cards_per_player);
     players_cards.push_back(std::vector<int>(begin, end));
-    std::advance(begin, numCardsPerPlayer);
+    std::advance(begin, num_cards_per_player);
   }
 
   return {talon, players_cards};

--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -23,14 +23,14 @@ bool TarokCard::IsTrula() const {
   return suit == CardSuit::kTaroks && points == 5;
 }
 
-std::string TarokCard::ToString() const { return long_name; }
+const std::string TarokCard::ToString() const { return long_name; }
 
 // overload cards operator<< so that we can output instances on output stream
 std::ostream &operator<<(std::ostream &stream, const TarokCard &card) {
-  return stream << card.long_name;
+  return stream << card.ToString();
 }
 
-std::array<TarokCard, 54> InitializeCardDeck() {
+const std::array<TarokCard, 54> InitializeCardDeck() {
   static const std::array<TarokCard, 54> deck = {
       // taroks
       TarokCard(CardSuit::kTaroks, 8, 5, "T1", "Pagat"),

--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -109,6 +109,7 @@ DealtCards DealCards(int numPlayers, int seed) {
   // deal the rest of the cards to players
   int numCardsPerPlayer = 48 / numPlayers;
   std::vector<std::vector<int>> players_cards;
+  players_cards.reserve(numPlayers);
 
   std::advance(begin, 6);
   for (int i = 0; i < numPlayers; i++) {

--- a/tarok/src/cards.h
+++ b/tarok/src/cards.h
@@ -24,11 +24,10 @@ struct TarokCard {
   const std::string long_name;
 };
 
-using CardDeck = std::array<TarokCard, 54>;
-CardDeck InitializeCardDeck();
+std::array<TarokCard, 54> InitializeCardDeck();
 
 // a type for a pair holding talon and players' private cards
 using DealtCards = std::tuple<std::vector<int>, std::vector<std::vector<int>>>;
-DealtCards DealCards(int numPlayers, int seed);
+DealtCards DealCards(int num_players, int seed);
 
 }  // namespace tarok

--- a/tarok/src/cards.h
+++ b/tarok/src/cards.h
@@ -15,7 +15,7 @@ struct TarokCard {
             std::string long_name);
 
   bool IsTrula() const;
-  std::string ToString() const;
+  const std::string ToString() const;
 
   const CardSuit suit;
   const int rank;
@@ -24,7 +24,7 @@ struct TarokCard {
   const std::string long_name;
 };
 
-std::array<TarokCard, 54> InitializeCardDeck();
+const std::array<TarokCard, 54> InitializeCardDeck();
 
 // a type for a pair holding talon and players' private cards
 using DealtCards = std::tuple<std::vector<int>, std::vector<std::vector<int>>>;

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -16,7 +16,10 @@ TarokGame::TarokGame(const open_spiel::GameParameters& params)
       num_players_(ParameterValue<int>("num_players")),
       rng_(std::mt19937(ParameterValue<int>("seed") == -1
                             ? std::time(0)
-                            : ParameterValue<int>("seed"))) {}
+                            : ParameterValue<int>("seed"))) {
+  SPIEL_CHECK_GE(num_players_, kGameType.min_num_players);
+  SPIEL_CHECK_LE(num_players_, kGameType.max_num_players);
+}
 
 int TarokGame::NumDistinctActions() const {
   // todo: implement

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -11,26 +11,6 @@
 
 namespace tarok {
 
-// game facts
-inline static const open_spiel::GameType kGameType{
-    "tarok",            // short_name
-    "Slovenian Tarok",  // long_name
-    open_spiel::GameType::Dynamics::kSequential,
-    open_spiel::GameType::ChanceMode::kSampledStochastic,
-    open_spiel::GameType::Information::kImperfectInformation,
-    open_spiel::GameType::Utility::kGeneralSum,
-    open_spiel::GameType::RewardModel::kTerminal,
-    4,      // max_num_players
-    3,      // min_num_players
-    true,   // provides_information_state_string
-    false,  // provides_information_state_tensor
-    false,  // provides_observation_string
-    false,  // provides_observation_tensor
-    // parameter_specification
-    {{"num_players", open_spiel::GameParameter(kDefaultNumPLayers)},
-     {"seed", open_spiel::GameParameter(kDefaultSeed)}}};
-
-// game definition
 TarokGame::TarokGame(const open_spiel::GameParameters& params)
     : Game(kGameType, params),
       num_players_(ParameterValue<int>("num_players")),

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -33,12 +33,15 @@ const open_spiel::GameType kGameType{
 // game definition
 TarokGame::TarokGame(const open_spiel::GameParameters& params)
     : Game(kGameType, params),
-      num_players_(this->ParameterValue<int>("num_players")),
-      rng_(new std::mt19937(this->ParameterValue<int>("rng_seed") == -1
+      num_players_(ParameterValue<int>("num_players")),
+      rng_(new std::mt19937(ParameterValue<int>("rng_seed") == -1
                                 ? std::time(0)
-                                : this->ParameterValue<int>("rng_seed"))) {}
+                                : ParameterValue<int>("rng_seed"))) {}
 
-int TarokGame::NumDistinctActions() const { return 0; }
+int TarokGame::NumDistinctActions() const {
+  // todo: implement
+  return 0;
+}
 
 std::unique_ptr<open_spiel::State> TarokGame::NewInitialState() const {
   return NewInitialTarokState();
@@ -48,17 +51,32 @@ std::unique_ptr<TarokState> TarokGame::NewInitialTarokState() const {
   return std::unique_ptr<TarokState>(new TarokState(shared_from_this()));
 }
 
+int TarokGame::MaxChanceOutcomes() const {
+  // game is implicitly stochastic
+  return 1;
+}
+
 int TarokGame::NumPlayers() const { return num_players_; }
 
-double TarokGame::MinUtility() const { return 0.0; }
+double TarokGame::MinUtility() const {
+  // todo: implement
+  return 0.0;
+}
 
-double TarokGame::MaxUtility() const { return 0.0; }
+double TarokGame::MaxUtility() const {
+  // todo: implement
+  return 0.0;
+}
 
 std::shared_ptr<const open_spiel::Game> TarokGame::Clone() const {
+  // todo: implement
   return nullptr;
 }
 
-int TarokGame::MaxGameLength() const { return 0; }
+int TarokGame::MaxGameLength() const {
+  // todo: implement
+  return 0;
+}
 
 int TarokGame::ShuffleCardDeckSeed() const { return rng_->operator()(); }
 

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<open_spiel::State> TarokGame::NewInitialState() const {
 }
 
 std::unique_ptr<TarokState> TarokGame::NewInitialTarokState() const {
-  return std::unique_ptr<TarokState>(new TarokState(shared_from_this()));
+  return std::make_unique<TarokState>(shared_from_this());
 }
 
 int TarokGame::MaxChanceOutcomes() const {
@@ -65,7 +65,7 @@ int TarokGame::RNG() const { return rng_(); }
 
 std::shared_ptr<const TarokGame> NewTarokGame(
     const open_spiel::GameParameters& params) {
-  return std::shared_ptr<const TarokGame>(new TarokGame(params));
+  return std::make_shared<const TarokGame>(params);
 }
 
 }  // namespace tarok

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -12,7 +12,7 @@
 namespace tarok {
 
 // game facts
-const open_spiel::GameType kGameType{
+inline static const open_spiel::GameType kGameType{
     "tarok",            // short_name
     "Slovenian Tarok",  // long_name
     open_spiel::GameType::Dynamics::kSequential,

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -34,9 +34,9 @@ const open_spiel::GameType kGameType{
 TarokGame::TarokGame(const open_spiel::GameParameters& params)
     : Game(kGameType, params),
       num_players_(ParameterValue<int>("num_players")),
-      rng_(new std::mt19937(ParameterValue<int>("seed") == -1
-                                ? std::time(0)
-                                : ParameterValue<int>("seed"))) {}
+      rng_(std::mt19937(ParameterValue<int>("seed") == -1
+                            ? std::time(0)
+                            : ParameterValue<int>("seed"))) {}
 
 int TarokGame::NumDistinctActions() const {
   // todo: implement
@@ -78,7 +78,7 @@ int TarokGame::MaxGameLength() const {
   return 0;
 }
 
-int TarokGame::ShuffleCardDeckSeed() const { return rng_->operator()(); }
+int TarokGame::RNG() const { return rng_(); }
 
 std::shared_ptr<const TarokGame> NewTarokGame(
     const open_spiel::GameParameters& params) {

--- a/tarok/src/game.cpp
+++ b/tarok/src/game.cpp
@@ -28,15 +28,15 @@ const open_spiel::GameType kGameType{
     false,  // provides_observation_tensor
     // parameter_specification
     {{"num_players", open_spiel::GameParameter(kDefaultNumPLayers)},
-     {"rng_seed", open_spiel::GameParameter(kDefaultRngSeed)}}};
+     {"seed", open_spiel::GameParameter(kDefaultSeed)}}};
 
 // game definition
 TarokGame::TarokGame(const open_spiel::GameParameters& params)
     : Game(kGameType, params),
       num_players_(ParameterValue<int>("num_players")),
-      rng_(new std::mt19937(ParameterValue<int>("rng_seed") == -1
+      rng_(new std::mt19937(ParameterValue<int>("seed") == -1
                                 ? std::time(0)
-                                : ParameterValue<int>("rng_seed"))) {}
+                                : ParameterValue<int>("seed"))) {}
 
 int TarokGame::NumDistinctActions() const {
   // todo: implement
@@ -79,10 +79,6 @@ int TarokGame::MaxGameLength() const {
 }
 
 int TarokGame::ShuffleCardDeckSeed() const { return rng_->operator()(); }
-
-TarokCard TarokGame::ActionToCard(open_spiel::Action action) const {
-  return kCardDeck[action];
-}
 
 std::shared_ptr<const TarokGame> NewTarokGame(
     const open_spiel::GameParameters& params) {

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 
 #include "open_spiel/spiel.h"
@@ -35,7 +36,8 @@ class TarokGame : public open_spiel::Game {
   // for shuffling the cards
   int RNG() const;
 
-  inline static const CardDeck kCardDeck = InitializeCardDeck();
+  inline static const std::array<TarokCard, 54> card_deck_ =
+      InitializeCardDeck();
   const int num_players_;
   mutable std::mt19937 rng_;
 };

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -21,24 +21,25 @@ class TarokGame : public open_spiel::Game {
   int NumDistinctActions() const override;
   std::unique_ptr<open_spiel::State> NewInitialState() const override;
   std::unique_ptr<TarokState> NewInitialTarokState() const;
-  // int MaxChanceOutcomes() const override;
+  int MaxChanceOutcomes() const override;
   int NumPlayers() const override;
   double MinUtility() const override;
   double MaxUtility() const override;
   std::shared_ptr<const Game> Clone() const override;
-  // double UtilitySum() const override;
   int MaxGameLength() const override;
-  int ShuffleCardDeckSeed() const;
   TarokCard ActionToCard(open_spiel::Action action) const;
 
  private:
+  friend class TarokState;
+  int ShuffleCardDeckSeed() const;
+
   inline static const CardDeck kCardDeck = InitializeCardDeck();
-  int num_players_;
+  const int num_players_;
   std::unique_ptr<std::mt19937> rng_;
 };
 
-// instantiate the game instance via a shared_ptr
-// (see Game declaration comments in open_spiel/spiel.h)
+// instantiate the game instance via a shared_ptr, see game declaration
+// comments in open_spiel/spiel.h for more info
 std::shared_ptr<const TarokGame> NewTarokGame(
     const open_spiel::GameParameters& params);
 

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -50,9 +50,11 @@ class TarokGame : public open_spiel::Game {
 
  private:
   friend class TarokState;
-  // this function is const so that it can be called from state instances,
+  // this function is const so that it can be called from state objects,
   // note that it nevertheless changes the state of the mutable rng_ used
-  // for shuffling the cards
+  // for shuffling the cards, this is expected behaviour since the game
+  // object has to maintain an internal RNG state due to implicit stochasticity,
+  // see ChanceOutcomes() comments in open_spiel/spiel.h for more info
   int RNG() const;
 
   inline static const std::array<TarokCard, 54> card_deck_ =

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -15,6 +15,25 @@ inline constexpr int kDefaultNumPLayers = 3;
 // seed for shuffling the cards, -1 means seeded by clock
 inline constexpr int kDefaultSeed = -1;
 
+// game facts
+inline static const open_spiel::GameType kGameType{
+    "tarok",            // short_name
+    "Slovenian Tarok",  // long_name
+    open_spiel::GameType::Dynamics::kSequential,
+    open_spiel::GameType::ChanceMode::kSampledStochastic,
+    open_spiel::GameType::Information::kImperfectInformation,
+    open_spiel::GameType::Utility::kGeneralSum,
+    open_spiel::GameType::RewardModel::kTerminal,
+    4,      // max_num_players
+    3,      // min_num_players
+    true,   // provides_information_state_string
+    false,  // provides_information_state_tensor
+    false,  // provides_observation_string
+    false,  // provides_observation_tensor
+    // parameter_specification
+    {{"num_players", open_spiel::GameParameter(kDefaultNumPLayers)},
+     {"seed", open_spiel::GameParameter(kDefaultSeed)}}};
+
 class TarokGame : public open_spiel::Game {
  public:
   explicit TarokGame(const open_spiel::GameParameters& params);

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -30,11 +30,14 @@ class TarokGame : public open_spiel::Game {
 
  private:
   friend class TarokState;
-  int ShuffleCardDeckSeed() const;
+  // this function is const so that it can be called from state instances,
+  // note that it nevertheless changes the state of the mutable rng_ used
+  // for shuffling the cards
+  int RNG() const;
 
   inline static const CardDeck kCardDeck = InitializeCardDeck();
   const int num_players_;
-  std::unique_ptr<std::mt19937> rng_;
+  mutable std::mt19937 rng_;
 };
 
 // instantiate the game instance via a shared_ptr, see game declaration

--- a/tarok/src/game.h
+++ b/tarok/src/game.h
@@ -12,7 +12,7 @@ namespace tarok {
 
 inline constexpr int kDefaultNumPLayers = 3;
 // seed for shuffling the cards, -1 means seeded by clock
-inline constexpr int kDefaultRngSeed = -1;
+inline constexpr int kDefaultSeed = -1;
 
 class TarokGame : public open_spiel::Game {
  public:
@@ -27,7 +27,6 @@ class TarokGame : public open_spiel::Game {
   double MaxUtility() const override;
   std::shared_ptr<const Game> Clone() const override;
   int MaxGameLength() const override;
-  TarokCard ActionToCard(open_spiel::Action action) const;
 
  private:
   friend class TarokState;

--- a/tarok/src/py_bindings.cpp
+++ b/tarok/src/py_bindings.cpp
@@ -17,18 +17,19 @@ PYBIND11_MODULE(pytarok, m) {
   // game object
   py::class_<TarokGame, open_spiel::Game, std::shared_ptr<TarokGame>>
       tarok_game(m, "TarokGame");
-
+  // game object constructor
   tarok_game.def(py::init([](const open_spiel::GameParameters& params) {
     // instantiate the game instance via a shared_ptr, see game declaration
     // comments in open_spiel/spiel.h for more info
     return std::shared_ptr<TarokGame>(new TarokGame(params));
   }));
-
   tarok_game.def("new_initial_tarok_state", &TarokGame::NewInitialTarokState);
   tarok_game.def("action_to_card", &TarokGame::ActionToCard);
 
   // state object
   py::class_<TarokState, open_spiel::State> tarok_state(m, "TarokState");
+  tarok_state.def("talon", &TarokState::Talon);
+  tarok_state.def("player_cards", &TarokState::PlayerCards);
 
   // card object
   py::class_<TarokCard> tarok_card(m, "TarokCard");

--- a/tarok/src/py_bindings.cpp
+++ b/tarok/src/py_bindings.cpp
@@ -24,7 +24,6 @@ PYBIND11_MODULE(pytarok, m) {
     return std::shared_ptr<TarokGame>(new TarokGame(params));
   }));
   tarok_game.def("new_initial_tarok_state", &TarokGame::NewInitialTarokState);
-  tarok_game.def("action_to_card", &TarokGame::ActionToCard);
 
   // state object
   py::class_<TarokState, open_spiel::State> tarok_state(m, "TarokState");

--- a/tarok/src/py_bindings.cpp
+++ b/tarok/src/py_bindings.cpp
@@ -19,8 +19,8 @@ PYBIND11_MODULE(pytarok, m) {
       tarok_game(m, "TarokGame");
 
   tarok_game.def(py::init([](const open_spiel::GameParameters& params) {
-    // instantiate the game instance via a shared_ptr
-    // (see Game declaration comments in open_spiel/spiel.h)
+    // instantiate the game instance via a shared_ptr, see game declaration
+    // comments in open_spiel/spiel.h for more info
     return std::shared_ptr<TarokGame>(new TarokGame(params));
   }));
 

--- a/tarok/src/py_bindings.cpp
+++ b/tarok/src/py_bindings.cpp
@@ -1,5 +1,7 @@
 /* Copyright 2020 Semantic Weights. All rights reserved. */
 
+#include <memory>
+
 #include "open_spiel/spiel.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
@@ -21,7 +23,7 @@ PYBIND11_MODULE(pytarok, m) {
   tarok_game.def(py::init([](const open_spiel::GameParameters& params) {
     // instantiate the game instance via a shared_ptr, see game declaration
     // comments in open_spiel/spiel.h for more info
-    return std::shared_ptr<TarokGame>(new TarokGame(params));
+    return std::make_shared<TarokGame>(params);
   }));
   tarok_game.def("new_initial_tarok_state", &TarokGame::NewInitialTarokState);
 

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "open_spiel/spiel.h"
+#include "src/cards.h"
 #include "src/game.h"
 
 namespace tarok {
@@ -14,46 +15,103 @@ namespace tarok {
 // state definition
 TarokState::TarokState(std::shared_ptr<const open_spiel::Game> game)
     : open_spiel::State(game),
-      tarok_parent_game_(static_cast<const TarokGame&>(*game)) {
-  std::tie(talon_, players_cards) =
-      DealCards(game->NumPlayers(), tarok_parent_game_.ShuffleCardDeckSeed());
-}
+      tarok_parent_game_(static_cast<const TarokGame&>(*game)),
+      current_game_phase_(GamePhase::kCardDealing),
+      current_player_(open_spiel::kChancePlayerId) {}
 
-open_spiel::Player TarokState::CurrentPlayer() const { return -1; }
+open_spiel::Player TarokState::CurrentPlayer() const { return current_player_; }
 
 std::vector<open_spiel::Action> TarokState::LegalActions() const {
-  return std::vector<open_spiel::Action>{};
+  switch (current_game_phase_) {
+    case GamePhase::kCardDealing:
+      // return a dummy action due to implicit stochasticity
+      return {0};
+    case GamePhase::kBidding:
+      // todo: implement
+      return {};
+    case GamePhase::kTalonExchange:
+      // todo: implement
+      return {};
+    case GamePhase::kTricksPlaying:
+      // todo: implement
+      return {};
+    case GamePhase::kFinished:
+      return {};
+  }
 }
 
 std::string TarokState::ActionToString(open_spiel::Player player,
                                        open_spiel::Action action_id) const {
+  // todo: implement
   return "";
 }
 
 open_spiel::Action TarokState::StringToAction(
     open_spiel::Player player, const std::string& action_str) const {
-  return open_spiel::Action();
+  // todo: implement
+  return 0;
 }
 
-std::string TarokState::ToString() const { return ""; }
+std::string TarokState::ToString() const {
+  // todo: implement
+  return "";
+}
 
-bool TarokState::IsTerminal() const { return true; }
+bool TarokState::IsTerminal() const {
+  return current_game_phase_ == GamePhase::kFinished;
+}
 
 std::vector<double> TarokState::Returns() const {
-  return std::vector<double>{};
+  // todo: implement
+  return {};
 }
 
 std::string TarokState::InformationStateString(
     open_spiel::Player player) const {
+  // todo: implement
   return "";
 }
 
-std::unique_ptr<open_spiel::State> TarokState::Clone() const { return nullptr; }
-
-open_spiel::ActionsAndProbs TarokState::ChanceOutcomes() const {
-  return open_spiel::ActionsAndProbs();
+std::unique_ptr<open_spiel::State> TarokState::Clone() const {
+  // todo: implement
+  return nullptr;
 }
 
-void TarokState::DoApplyAction(open_spiel::Action action_id) {}
+open_spiel::ActionsAndProbs TarokState::ChanceOutcomes() const {
+  if (current_game_phase_ == GamePhase::kCardDealing) {
+    // return a dummy action with probability 1 due to implicit stochasticity
+    return {{0, 1.0}};
+  }
+  return {};
+}
+
+void TarokState::DoApplyAction(open_spiel::Action action_id) {
+  // todo: we should probably check that action is legal for the current player
+  switch (current_game_phase_) {
+    case GamePhase::kCardDealing:
+      DoApplyActionInCardDealing();
+      break;
+    case GamePhase::kBidding:
+      // todo: implement
+      break;
+    case GamePhase::kTalonExchange:
+      // todo: implement
+      break;
+    case GamePhase::kTricksPlaying:
+      // todo: implement
+      break;
+    case GamePhase::kFinished:
+      open_spiel::SpielFatalError("Calling DoApplyAction on a terminal state.");
+  }
+}
+
+void TarokState::DoApplyActionInCardDealing() {
+  // do the actual sampling here due to implicit stochasticity
+  std::tie(talon_, players_cards_) =
+      DealCards(tarok_parent_game_.NumPlayers(),
+                tarok_parent_game_.ShuffleCardDeckSeed());
+  current_game_phase_ = GamePhase::kBidding;
+  current_player_ = 0;
+}
 
 }  // namespace tarok

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -97,6 +97,9 @@ open_spiel::ActionsAndProbs TarokState::ChanceOutcomes() const {
 std::vector<int> TarokState::Talon() const { return talon_; }
 
 std::vector<int> TarokState::PlayerCards(open_spiel::Player player) const {
+  if (current_game_phase_ == GamePhase::kCardDealing) {
+    return {};
+  }
   return players_cards_.at(player);
 }
 

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -87,19 +87,16 @@ std::unique_ptr<open_spiel::State> TarokState::Clone() const {
 }
 
 open_spiel::ActionsAndProbs TarokState::ChanceOutcomes() const {
-  if (current_game_phase_ == GamePhase::kCardDealing) {
+  if (current_game_phase_ == GamePhase::kCardDealing)
     // return a dummy action with probability 1 due to implicit stochasticity
     return {{0, 1.0}};
-  }
   return {};
 }
 
 std::vector<int> TarokState::Talon() const { return talon_; }
 
 std::vector<int> TarokState::PlayerCards(open_spiel::Player player) const {
-  if (current_game_phase_ == GamePhase::kCardDealing) {
-    return {};
-  }
+  if (current_game_phase_ == GamePhase::kCardDealing) return {};
   return players_cards_.at(player);
 }
 

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -15,7 +15,7 @@ namespace tarok {
 // state definition
 TarokState::TarokState(std::shared_ptr<const open_spiel::Game> game)
     : open_spiel::State(game),
-      tarok_parent_game_(static_cast<const TarokGame&>(*game)),
+      tarok_parent_game_(std::static_pointer_cast<const TarokGame>(game)),
       current_game_phase_(GamePhase::kCardDealing),
       current_player_(0) {}
 
@@ -123,8 +123,7 @@ void TarokState::DoApplyAction(open_spiel::Action action_id) {
 void TarokState::DoApplyActionInCardDealing() {
   // do the actual sampling here due to implicit stochasticity
   std::tie(talon_, players_cards_) =
-      DealCards(tarok_parent_game_.NumPlayers(),
-                tarok_parent_game_.ShuffleCardDeckSeed());
+      DealCards(tarok_parent_game_->NumPlayers(), tarok_parent_game_->RNG());
   current_game_phase_ = GamePhase::kBidding;
 }
 

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -17,9 +17,18 @@ TarokState::TarokState(std::shared_ptr<const open_spiel::Game> game)
     : open_spiel::State(game),
       tarok_parent_game_(static_cast<const TarokGame&>(*game)),
       current_game_phase_(GamePhase::kCardDealing),
-      current_player_(open_spiel::kChancePlayerId) {}
+      current_player_(0) {}
 
-open_spiel::Player TarokState::CurrentPlayer() const { return current_player_; }
+open_spiel::Player TarokState::CurrentPlayer() const {
+  switch (current_game_phase_) {
+    case GamePhase::kCardDealing:
+      return open_spiel::kChancePlayerId;
+    case GamePhase::kFinished:
+      return open_spiel::kTerminalPlayerId;
+    default:
+      return current_player_;
+  }
+}
 
 std::vector<open_spiel::Action> TarokState::LegalActions() const {
   switch (current_game_phase_) {
@@ -85,6 +94,12 @@ open_spiel::ActionsAndProbs TarokState::ChanceOutcomes() const {
   return {};
 }
 
+std::vector<int> TarokState::Talon() const { return talon_; }
+
+std::vector<int> TarokState::PlayerCards(open_spiel::Player player) const {
+  return players_cards_.at(player);
+}
+
 void TarokState::DoApplyAction(open_spiel::Action action_id) {
   // todo: we should probably check that action is legal for the current player
   switch (current_game_phase_) {
@@ -111,7 +126,6 @@ void TarokState::DoApplyActionInCardDealing() {
       DealCards(tarok_parent_game_.NumPlayers(),
                 tarok_parent_game_.ShuffleCardDeckSeed());
   current_game_phase_ = GamePhase::kBidding;
-  current_player_ = 0;
 }
 
 }  // namespace tarok

--- a/tarok/src/state.h
+++ b/tarok/src/state.h
@@ -45,7 +45,7 @@ class TarokState : public open_spiel::State {
  private:
   void DoApplyActionInCardDealing();
 
-  const TarokGame& tarok_parent_game_;
+  std::shared_ptr<const TarokGame> tarok_parent_game_;
   GamePhase current_game_phase_;
   open_spiel::Player current_player_;
   std::vector<int> talon_;

--- a/tarok/src/state.h
+++ b/tarok/src/state.h
@@ -10,6 +10,14 @@
 
 namespace tarok {
 
+enum class GamePhase {
+  kCardDealing,
+  kBidding,
+  kTalonExchange,
+  kTricksPlaying,
+  kFinished
+};
+
 class TarokGame;
 
 class TarokState : public open_spiel::State {
@@ -33,9 +41,13 @@ class TarokState : public open_spiel::State {
   void DoApplyAction(open_spiel::Action action_id) override;
 
  private:
+  void DoApplyActionInCardDealing();
+
   const TarokGame& tarok_parent_game_;
+  GamePhase current_game_phase_;
+  open_spiel::Player current_player_;
   std::vector<int> talon_;
-  std::vector<std::vector<int>> players_cards;
+  std::vector<std::vector<int>> players_cards_;
 };
 
 }  // namespace tarok

--- a/tarok/src/state.h
+++ b/tarok/src/state.h
@@ -36,6 +36,8 @@ class TarokState : public open_spiel::State {
   std::string InformationStateString(open_spiel::Player player) const override;
   std::unique_ptr<State> Clone() const override;
   open_spiel::ActionsAndProbs ChanceOutcomes() const override;
+  std::vector<int> Talon() const;
+  std::vector<int> PlayerCards(open_spiel::Player player) const;
 
  protected:
   void DoApplyAction(open_spiel::Action action_id) override;

--- a/tarok/test/CMakeLists.txt
+++ b/tarok/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # build the test runner binary
-add_executable(tarok_tests game_tests.cpp cards_tests.cpp)
-target_link_libraries(tarok_tests gtest_main tarok_lib)
+add_executable(tarok_tests game_tests.cpp state_tests.cpp cards_tests.cpp)
+target_link_libraries(tarok_tests gtest_main gmock tarok_lib)
 add_test(NAME all_tests COMMAND run)
 
 # build the debugging runner binary

--- a/tarok/test/cards_tests.cpp
+++ b/tarok/test/cards_tests.cpp
@@ -21,7 +21,7 @@ class TarokCardsTests : public ::testing::Test {
 
 TEST_F(TarokCardsTests, TestDealtCardsSize) {
   EXPECT_EQ(talon_.size(), 6);
-  for (auto &player_cards : players_cards_) {
+  for (auto const& player_cards : players_cards_) {
     EXPECT_EQ(player_cards.size(), 16);
   }
 }
@@ -29,7 +29,7 @@ TEST_F(TarokCardsTests, TestDealtCardsSize) {
 TEST_F(TarokCardsTests, TestDealtCardsContent) {
   // flatten and sort all the dealt cards
   std::vector<int> all_dealt_cards(talon_.begin(), talon_.end());
-  for (auto &player_cards : players_cards_) {
+  for (auto const& player_cards : players_cards_) {
     all_dealt_cards.insert(all_dealt_cards.end(), player_cards.begin(),
                            player_cards.end());
   }

--- a/tarok/test/debugging_runner.cpp
+++ b/tarok/test/debugging_runner.cpp
@@ -1,14 +1,22 @@
 /* Copyright 2020 Semantic Weights. All rights reserved. */
 
+#include <iostream>
+
 #include "open_spiel/spiel.h"
 #include "src/game.h"
 
 int main() {
-  auto params =
-      open_spiel::GameParameters({{"rng_seed", open_spiel::GameParameter(0)}});
-  auto game = tarok::NewTarokGame(params);
-  auto state1 = game->NewInitialTarokState();
-  auto state2 = game->NewInitialTarokState();
+  auto game = tarok::NewTarokGame(
+      open_spiel::GameParameters({{"seed", open_spiel::GameParameter(0)}}));
+
+  auto state = game->NewInitialTarokState();
+  std::cout << "Current player: " << state->CurrentPlayer() << std::endl;
+  std::cout << "Talon size: " << state->Talon().size() << "\n" << std::endl;
+
+  std::cout << "Dealing cards..." << std::endl;
+  state->ApplyAction(0);
+  std::cout << "Current player: " << state->CurrentPlayer() << std::endl;
+  std::cout << "Talon size: " << state->Talon().size() << std::endl;
 
   return 0;
 }

--- a/tarok/test/game_tests.cpp
+++ b/tarok/test/game_tests.cpp
@@ -16,7 +16,7 @@ TEST(TarokGameTests, TestDefaultNumPlayers) {
 
 TEST(TarokGameTests, TestCardDeckShufflingSeed) {
   auto game = tarok::NewTarokGame(
-      open_spiel::GameParameters({{"rng_seed", open_spiel::GameParameter(0)}}));
+      open_spiel::GameParameters({{"seed", open_spiel::GameParameter(0)}}));
   // subsequent shuffles within the same game should be different
   auto state1 = game->NewInitialTarokState();
   state1->ApplyAction(0);
@@ -25,7 +25,7 @@ TEST(TarokGameTests, TestCardDeckShufflingSeed) {
   EXPECT_NE(state1->Talon(), state2->Talon());
 
   game = tarok::NewTarokGame(
-      open_spiel::GameParameters({{"rng_seed", open_spiel::GameParameter(0)}}));
+      open_spiel::GameParameters({{"seed", open_spiel::GameParameter(0)}}));
   // shuffles should be the same when recreating a game with the same seed
   auto state3 = game->NewInitialTarokState();
   state3->ApplyAction(0);

--- a/tarok/test/game_tests.cpp
+++ b/tarok/test/game_tests.cpp
@@ -14,24 +14,25 @@ TEST(TarokGameTests, TestDefaultNumPlayers) {
   EXPECT_EQ(game->NumPlayers(), 4);
 }
 
-// todo: enable and implement this test when information strings are implemented
-TEST(TarokGameTests, DISABLED_TestCardDeckShufflingSeed) {
+TEST(TarokGameTests, TestCardDeckShufflingSeed) {
   auto game = tarok::NewTarokGame(
       open_spiel::GameParameters({{"rng_seed", open_spiel::GameParameter(0)}}));
-  auto state1 = game->NewInitialTarokState();
-  auto state2 = game->NewInitialTarokState();
   // subsequent shuffles within the same game should be different
-  EXPECT_NE(state1, state2);
+  auto state1 = game->NewInitialTarokState();
+  state1->ApplyAction(0);
+  auto state2 = game->NewInitialTarokState();
+  state2->ApplyAction(0);
+  EXPECT_NE(state1->Talon(), state2->Talon());
 
   game = tarok::NewTarokGame(
       open_spiel::GameParameters({{"rng_seed", open_spiel::GameParameter(0)}}));
-  auto state3 = game->NewInitialTarokState();
-  auto state4 = game->NewInitialTarokState();
-  EXPECT_NE(state3, state4);
-
   // shuffles should be the same when recreating a game with the same seed
-  EXPECT_EQ(state1, state3);
-  EXPECT_EQ(state2, state4);
+  auto state3 = game->NewInitialTarokState();
+  state3->ApplyAction(0);
+  auto state4 = game->NewInitialTarokState();
+  state4->ApplyAction(0);
+  EXPECT_EQ(state1->Talon(), state3->Talon());
+  EXPECT_EQ(state2->Talon(), state4->Talon());
 }
 
 }  // namespace tarok

--- a/tarok/test/state_tests.cpp
+++ b/tarok/test/state_tests.cpp
@@ -20,9 +20,9 @@ TEST(TarokStateTests, TestCardDealingPhase) {
 
   state->ApplyAction(0);
   EXPECT_EQ(state->CurrentPlayer(), 0);
-  EXPECT_TRUE(!state->Talon().empty());
+  EXPECT_FALSE(state->Talon().empty());
   for (int i = 0; i < game->NumPlayers(); i++) {
-    EXPECT_TRUE(!state->PlayerCards(i).empty());
+    EXPECT_FALSE(state->PlayerCards(i).empty());
   }
 }
 

--- a/tarok/test/state_tests.cpp
+++ b/tarok/test/state_tests.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2020 Semantic Weights. All rights reserved. */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "open_spiel/spiel.h"
+#include "src/game.h"
+
+namespace tarok {
+
+TEST(TarokStateTests, TestCardDealingPhase) {
+  auto game = tarok::NewTarokGame(open_spiel::GameParameters());
+  auto state = game->NewInitialTarokState();
+  EXPECT_EQ(state->CurrentPlayer(), open_spiel::kChancePlayerId);
+  EXPECT_TRUE(state->Talon().empty());
+  for (int i = 0; i < game->NumPlayers(); i++) {
+    EXPECT_TRUE(state->PlayerCards(i).empty());
+  }
+  EXPECT_EQ(state->LegalActions().size(), 1);
+  ASSERT_THAT(state->LegalActions(), testing::ElementsAre(0));
+
+  state->ApplyAction(0);
+  EXPECT_EQ(state->CurrentPlayer(), 0);
+  EXPECT_TRUE(!state->Talon().empty());
+  for (int i = 0; i < game->NumPlayers(); i++) {
+    EXPECT_TRUE(!state->PlayerCards(i).empty());
+  }
+}
+
+}  // namespace tarok


### PR DESCRIPTION
Prepare the ground for getting legal actions and applying them in different game phases. Note that player 0 always starts the game; this provides for a much cleaner implementation since the game instance doesn't have to keep the state about the starting player. In practice, this simply means that outside callers should rotate player IDs instead.