### PR TITLE
Simplify counting cards and make tests more readable.

### DIFF
--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -119,9 +119,9 @@ int CardPoints(const std::vector<open_spiel::Action>& actions,
                const std::array<Card, 54>& deck) {
   float points = 0;
   for (int i = 0; i < actions.size(); i++) {
-    points += (float)(deck.at(actions.at(i)).points) - 0.666;
+    points += static_cast<float>(deck.at(actions.at(i)).points) - 0.666;
   }
-  return (int)round(points);
+  return static_cast<int>(round(points));
 }
 
 }  // namespace tarok

--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -117,10 +117,15 @@ void Shuffle(std::vector<open_spiel::Action>* actions, std::mt19937&& rng) {
 
 int CardPoints(const std::vector<open_spiel::Action>& actions,
                const std::array<Card, 54>& deck) {
+  // count cards is done in batches of three. for every batch we sum up points
+  // from all three cards and subtract 2. if the last batch doesn't have three
+  // cards then subtract only 1.
+  // mathematically this is equevalent to subtracting 2/3 from each card.
   float points = 0;
-  for (int i = 0; i < actions.size(); i++) {
-    points += static_cast<float>(deck.at(actions.at(i)).points) - 0.666;
+  for (auto const& action : actions) {
+    points += deck.at(action).points;
   }
+  points -= actions.size() * 0.666f;
   return static_cast<int>(round(points));
 }
 

--- a/tarok/src/cards.cpp
+++ b/tarok/src/cards.cpp
@@ -117,24 +117,11 @@ void Shuffle(std::vector<open_spiel::Action>* actions, std::mt19937&& rng) {
 
 int CardPoints(const std::vector<open_spiel::Action>& actions,
                const std::array<Card, 54>& deck) {
-  int points = 0;
-  // count cards in batches of three
-  for (int i = 0; i < actions.size() / 3 * 3; i += 3) {
-    points +=
-        (deck.at(actions.at(i)).points + deck.at(actions.at(i + 1)).points +
-         deck.at(actions.at(i + 2)).points) -
-        2;
+  float points = 0;
+  for (int i = 0; i < actions.size(); i++) {
+    points += (float)(deck.at(actions.at(i)).points) - 0.666;
   }
-  // count the ramainder of the cards (0, 1 or 2 that are left at the end)
-  int cards_left = actions.size() % 3;
-  if (cards_left == 1) {
-    points += deck.at(actions.back()).points - 1;
-  } else if (cards_left == 2) {
-    points += (deck.at(actions.back()).points +
-               deck.at(actions.at(actions.size() - 2)).points) -
-              1;
-  }
-  return points;
+  return (int)round(points);
 }
 
 }  // namespace tarok

--- a/tarok/test/cards_tests.cpp
+++ b/tarok/test/cards_tests.cpp
@@ -49,36 +49,26 @@ TEST_F(CardsTests, TestPlayersCardsSorted) {
 }
 
 TEST_F(CardsTests, TestCountCards) {
-  auto deck = tarok::InitializeCardDeck();
+  auto deck = InitializeCardDeck();
   std::vector<open_spiel::Action> all_card_actions(54);
   std::iota(all_card_actions.begin(), all_card_actions.end(), 0);
-  EXPECT_EQ(tarok::CardPoints(all_card_actions, deck), 70);
-  EXPECT_EQ(tarok::CardPoints({}, deck), 0);
+  EXPECT_EQ(CardPoints(all_card_actions, deck), 70);
+  EXPECT_EQ(CardPoints({}, deck), 0);
+  EXPECT_EQ(CardPoints(CardLongNamesToActions({"II"}, deck), deck), 0);
+  EXPECT_EQ(CardPoints(CardLongNamesToActions({"II", "III"}, deck), deck), 1);
+  EXPECT_EQ(CardPoints(CardLongNamesToActions({"Mond"}, deck), deck), 4);
 
-  auto cards = {ActionFromCardName("XIV", deck)};
-  EXPECT_EQ(tarok::CardPoints(cards, deck), 0);
+  std::vector<std::string> cards{"Mond", "Jack of Diamonds"};
+  EXPECT_EQ(CardPoints(CardLongNamesToActions(cards, deck), deck), 6);
 
-  cards = {ActionFromCardName("Mond", deck)};
-  EXPECT_EQ(tarok::CardPoints(cards, deck), 4);
+  cards = {"XIV", "Mond", "Jack of Diamonds"};
+  EXPECT_EQ(CardPoints(CardLongNamesToActions(cards, deck), deck), 6);
 
-  cards = {ActionFromCardName("Mond", deck),
-           ActionFromCardName("Jack of Diamonds", deck)};
-  EXPECT_EQ(tarok::CardPoints(cards, deck), 6);
+  cards = {"XIV", "Mond", "Jack of Diamonds", "Queen of Diamonds"};
+  EXPECT_EQ(CardPoints(CardLongNamesToActions(cards, deck), deck), 9);
 
-  cards = {ActionFromCardName("XIV", deck), ActionFromCardName("Mond", deck),
-           ActionFromCardName("Jack of Diamonds", deck)};
-  EXPECT_EQ(tarok::CardPoints(cards, deck), 6);
-
-  cards = {ActionFromCardName("XIV", deck), ActionFromCardName("Mond", deck),
-           ActionFromCardName("Jack of Diamonds", deck),
-           ActionFromCardName("Queen of Diamonds", deck)};
-  EXPECT_EQ(tarok::CardPoints(cards, deck), 9);
-
-  cards = {ActionFromCardName("XIV", deck), ActionFromCardName("Mond", deck),
-           ActionFromCardName("Jack of Diamonds", deck),
-           ActionFromCardName("Queen of Diamonds", deck),
-           ActionFromCardName("King of Clubs", deck)};
-  EXPECT_EQ(tarok::CardPoints(cards, deck), 14);
+  cards = {"II", "Jack of Clubs", "Queen of Clubs", "Mond", "King of Clubs"};
+  EXPECT_EQ(CardPoints(CardLongNamesToActions(cards, deck), deck), 14);
 }
 
 }  // namespace tarok

--- a/tarok/test/cards_tests.cpp
+++ b/tarok/test/cards_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "gtest/gtest.h"
 #include "src/cards.h"
+#include "test/tarok_utils.h"
 
 namespace tarok {
 
@@ -53,9 +54,31 @@ TEST_F(CardsTests, TestCountCards) {
   std::iota(all_card_actions.begin(), all_card_actions.end(), 0);
   EXPECT_EQ(tarok::CardPoints(all_card_actions, deck), 70);
   EXPECT_EQ(tarok::CardPoints({}, deck), 0);
-  EXPECT_EQ(tarok::CardPoints({13, 20, 34}, deck), 6);
-  EXPECT_EQ(tarok::CardPoints({13, 20, 34, 36}, deck), 9);
-  EXPECT_EQ(tarok::CardPoints({13, 20, 34, 36, 53}, deck), 14);
+
+  auto cards = {ActionFromCardName("XIV", deck)};
+  EXPECT_EQ(tarok::CardPoints(cards, deck), 0);
+
+  cards = {ActionFromCardName("Mond", deck)};
+  EXPECT_EQ(tarok::CardPoints(cards, deck), 4);
+
+  cards = {ActionFromCardName("Mond", deck),
+           ActionFromCardName("Jack of Diamonds", deck)};
+  EXPECT_EQ(tarok::CardPoints(cards, deck), 6);
+
+  cards = {ActionFromCardName("XIV", deck), ActionFromCardName("Mond", deck),
+           ActionFromCardName("Jack of Diamonds", deck)};
+  EXPECT_EQ(tarok::CardPoints(cards, deck), 6);
+
+  cards = {ActionFromCardName("XIV", deck), ActionFromCardName("Mond", deck),
+           ActionFromCardName("Jack of Diamonds", deck),
+           ActionFromCardName("Queen of Diamonds", deck)};
+  EXPECT_EQ(tarok::CardPoints(cards, deck), 9);
+
+  cards = {ActionFromCardName("XIV", deck), ActionFromCardName("Mond", deck),
+           ActionFromCardName("Jack of Diamonds", deck),
+           ActionFromCardName("Queen of Diamonds", deck),
+           ActionFromCardName("King of Clubs", deck)};
+  EXPECT_EQ(tarok::CardPoints(cards, deck), 14);
 }
 
 }  // namespace tarok

--- a/tarok/test/tarok_utils.cpp
+++ b/tarok/test/tarok_utils.cpp
@@ -28,13 +28,23 @@ bool AllActionsInOtherActions(
   return true;
 }
 
-open_spiel::Action ActionFromCardName(std::string long_name,
-                                      const std::array<Card, 54>& deck) {
+open_spiel::Action CardLongNameToAction(std::string long_name,
+                                        const std::array<Card, 54>& deck) {
   for (int i = 0; i < deck.size(); i++) {
-    if (deck.at(i).long_name == long_name) {
-      return i;
-    }
+    if (deck.at(i).long_name == long_name) return i;
   }
-  throw "Invalid long_name!";
+  open_spiel::SpielFatalError("Invalid long_name!");
+  return -1;
+}
+
+std::vector<open_spiel::Action> CardLongNamesToActions(
+    const std::vector<std::string>& long_names,
+    const std::array<Card, 54>& deck) {
+  std::vector<open_spiel::Action> actions;
+  actions.reserve(long_names.size());
+  for (auto const long_name : long_names) {
+    actions.push_back(CardLongNameToAction(long_name, deck));
+  }
+  return actions;
 }
 }  // namespace tarok

--- a/tarok/test/tarok_utils.cpp
+++ b/tarok/test/tarok_utils.cpp
@@ -28,7 +28,7 @@ bool AllActionsInOtherActions(
   return true;
 }
 
-open_spiel::Action CardLongNameToAction(std::string long_name,
+open_spiel::Action CardLongNameToAction(const std::string& long_name,
                                         const std::array<Card, 54>& deck) {
   for (int i = 0; i < deck.size(); i++) {
     if (deck.at(i).long_name == long_name) return i;
@@ -47,4 +47,5 @@ std::vector<open_spiel::Action> CardLongNamesToActions(
   }
   return actions;
 }
+
 }  // namespace tarok

--- a/tarok/test/tarok_utils.cpp
+++ b/tarok/test/tarok_utils.cpp
@@ -28,4 +28,13 @@ bool AllActionsInOtherActions(
   return true;
 }
 
+open_spiel::Action ActionFromCardName(std::string long_name,
+                                      const std::array<Card, 54>& deck) {
+  for (int i = 0; i < deck.size(); i++) {
+    if (deck.at(i).long_name == long_name) {
+      return i;
+    }
+  }
+  throw "Invalid long_name!";
+}
 }  // namespace tarok

--- a/tarok/test/tarok_utils.h
+++ b/tarok/test/tarok_utils.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "src/game.h"
 
@@ -18,7 +18,10 @@ bool AllActionsInOtherActions(
     const std::vector<open_spiel::Action>& actions,
     const std::vector<open_spiel::Action>& other_actions);
 
-open_spiel::Action ActionFromCardName(std::string short_name,
-                                      const std::array<Card, 54>& deck);
+open_spiel::Action CardLongNameToAction(std::string long_name,
+                                        const std::array<Card, 54>& deck);
 
+std::vector<open_spiel::Action> CardLongNamesToActions(
+    const std::vector<std::string>& long_names,
+    const std::array<Card, 54>& deck);
 }  // namespace tarok

--- a/tarok/test/tarok_utils.h
+++ b/tarok/test/tarok_utils.h
@@ -24,4 +24,5 @@ open_spiel::Action CardLongNameToAction(const std::string& long_name,
 std::vector<open_spiel::Action> CardLongNamesToActions(
     const std::vector<std::string>& long_names,
     const std::array<Card, 54>& deck);
+    
 }  // namespace tarok

--- a/tarok/test/tarok_utils.h
+++ b/tarok/test/tarok_utils.h
@@ -24,5 +24,5 @@ open_spiel::Action CardLongNameToAction(const std::string& long_name,
 std::vector<open_spiel::Action> CardLongNamesToActions(
     const std::vector<std::string>& long_names,
     const std::array<Card, 54>& deck);
-    
+
 }  // namespace tarok

--- a/tarok/test/tarok_utils.h
+++ b/tarok/test/tarok_utils.h
@@ -17,4 +17,7 @@ bool AllActionsInOtherActions(
     const std::vector<open_spiel::Action>& actions,
     const std::vector<open_spiel::Action>& other_actions);
 
+open_spiel::Action ActionFromCardName(std::string short_name,
+                                      const std::array<Card, 54>& deck);
+
 }  // namespace tarok

--- a/tarok/test/tarok_utils.h
+++ b/tarok/test/tarok_utils.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "src/game.h"
 

--- a/tarok/test/tarok_utils.h
+++ b/tarok/test/tarok_utils.h
@@ -18,7 +18,7 @@ bool AllActionsInOtherActions(
     const std::vector<open_spiel::Action>& actions,
     const std::vector<open_spiel::Action>& other_actions);
 
-open_spiel::Action CardLongNameToAction(std::string long_name,
+open_spiel::Action CardLongNameToAction(const std::string& long_name,
                                         const std::array<Card, 54>& deck);
 
 std::vector<open_spiel::Action> CardLongNamesToActions(


### PR DESCRIPTION
Mathematically counting cards can be done by subtracting 2/3 from each card, which can greatly simplify the code.
Added a few more unit tests for edge cases and made them a bit more readable.