### PR TITLE
Fix talon exchange legal actions

### DIFF
--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -153,7 +153,7 @@ std::vector<open_spiel::Action> TarokState::LegalActionsInTalonExchange()
       actions.push_back(action);
   }
   // allow exchange of taroks (except of trula) if player has no other choice
-  if (actions.size() == 0) {
+  if (actions.empty()) {
     for (auto const& action : players_cards_.at(current_player_)) {
       if (ActionToCard(action).points != 5) actions.push_back(action);
     }

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -148,7 +148,7 @@ std::vector<open_spiel::Action> TarokState::LegalActionsInTalonExchange()
   // prevent exchange of taroks and kings
   std::vector<open_spiel::Action> actions;
   for (auto const& action : players_cards_.at(current_player_)) {
-    auto const& card = ActionToCard(action);
+    const Card& card = ActionToCard(action);
     if (card.suit != CardSuit::kTaroks && card.points != 5)
       actions.push_back(action);
   }

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -148,7 +148,7 @@ std::vector<open_spiel::Action> TarokState::LegalActionsInTalonExchange()
   // prevent exchange of taroks and kings
   std::vector<open_spiel::Action> actions;
   for (auto const& action : players_cards_.at(current_player_)) {
-    auto card = ActionToCard(action);
+    auto const& card = ActionToCard(action);
     if (card.suit != CardSuit::kTaroks && card.points != 5)
       actions.push_back(action);
   }

--- a/tarok/src/state.cpp
+++ b/tarok/src/state.cpp
@@ -145,10 +145,18 @@ std::vector<open_spiel::Action> TarokState::LegalActionsInTalonExchange()
     std::iota(actions.begin(), actions.end(), 0);
     return actions;
   }
-  // discarding the cards
+  // prevent exchange of taroks and kings
   std::vector<open_spiel::Action> actions;
   for (auto const& action : players_cards_.at(current_player_)) {
-    if (ActionToCard(action).points != 5) actions.push_back(action);
+    auto card = ActionToCard(action);
+    if (card.suit != CardSuit::kTaroks && card.points != 5)
+      actions.push_back(action);
+  }
+  // allow exchange of taroks (except of trula) if player has no other choice
+  if (actions.size() == 0) {
+    for (auto const& action : players_cards_.at(current_player_)) {
+      if (ActionToCard(action).points != 5) actions.push_back(action);
+    }
   }
   return actions;
 }

--- a/tarok/test/state_talon_exchange_phase_tests.cpp
+++ b/tarok/test/state_talon_exchange_phase_tests.cpp
@@ -215,7 +215,7 @@ TEST_F(TarokStateTests, TestTalonExchangePhase7) {
 
   // check taroks and kings are not in legal actions
   for (const auto& action : state->LegalActions()) {
-    const auto& card = deck_.at(action);
+    const Card& card = deck_.at(action);
     EXPECT_NE(card.suit, CardSuit::kTaroks);
     EXPECT_NE(card.points, 5);
   }
@@ -238,7 +238,7 @@ TEST_F(TarokStateTests, TestTalonExchangePhase8) {
   // first the player must exchange non-tarok or non-king card
   // check taroks and kings are not in legal actions
   for (const auto& action : state->LegalActions()) {
-    const auto& card = deck_.at(action);
+    const Card& card = deck_.at(action);
     EXPECT_NE(card.suit, CardSuit::kTaroks);
     EXPECT_NE(card.points, 5);
   }
@@ -249,7 +249,7 @@ TEST_F(TarokStateTests, TestTalonExchangePhase8) {
   // needs to exchange one card
   // check only taroks (no trula or kings) are in legal actions
   for (const auto& action : state->LegalActions()) {
-    const auto& card = deck_.at(action);
+    const Card& card = deck_.at(action);
     EXPECT_EQ(card.suit, CardSuit::kTaroks);
     EXPECT_NE(card.points, 5);
   }

--- a/tarok/test/state_talon_exchange_phase_tests.cpp
+++ b/tarok/test/state_talon_exchange_phase_tests.cpp
@@ -256,4 +256,5 @@ TEST_F(TarokStateTests, TestTalonExchangePhase8) {
   state->ApplyAction(state->LegalActions().at(0));
   EXPECT_EQ(state->CurrentGamePhase(), GamePhase::kTricksPlaying);
 }
+
 }  // namespace tarok

--- a/tarok/test/state_talon_exchange_phase_tests.cpp
+++ b/tarok/test/state_talon_exchange_phase_tests.cpp
@@ -215,7 +215,7 @@ TEST_F(TarokStateTests, TestTalonExchangePhase7) {
 
   // check taroks and kings are not in legal actions
   for (const auto& action : state->LegalActions()) {
-    auto card = deck_.at(action);
+    const auto& card = deck_.at(action);
     EXPECT_NE(card.suit, CardSuit::kTaroks);
     EXPECT_NE(card.points, 5);
   }
@@ -238,7 +238,7 @@ TEST_F(TarokStateTests, TestTalonExchangePhase8) {
   // first the player must exchange non-tarok or non-king card
   // check taroks and kings are not in legal actions
   for (const auto& action : state->LegalActions()) {
-    auto card = deck_.at(action);
+    const auto& card = deck_.at(action);
     EXPECT_NE(card.suit, CardSuit::kTaroks);
     EXPECT_NE(card.points, 5);
   }
@@ -249,7 +249,7 @@ TEST_F(TarokStateTests, TestTalonExchangePhase8) {
   // needs to exchange one card
   // check only taroks (no trula or kings) are in legal actions
   for (const auto& action : state->LegalActions()) {
-    auto card = deck_.at(action);
+    const auto& card = deck_.at(action);
     EXPECT_EQ(card.suit, CardSuit::kTaroks);
     EXPECT_NE(card.points, 5);
   }

--- a/tarok/test/tarok_utils.cpp
+++ b/tarok/test/tarok_utils.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<TarokState> StateAfterActions(
 bool AllActionsInOtherActions(
     const std::vector<open_spiel::Action>& actions,
     const std::vector<open_spiel::Action>& other_actions) {
-  for (const auto& action : actions) {
+  for (auto const& action : actions) {
     if (std::find(other_actions.begin(), other_actions.end(), action) ==
         other_actions.end()) {
       return false;


### PR DESCRIPTION
Allow exchange of taroks with talon only if no other card is available to exchange (e.g. the declarer has only taroks and kings). 

<b>Note:</b> If the tarok is being exchanged all other players must be informed about which tarok it is. This information must therefore be available through InformationState (TODO #30 ).